### PR TITLE
Alt itest vscode improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ litcli-debug
 # MacOS junk
 .DS_Store
 
+itest/regtest
 itest/btcd-itest
 itest/litd-itest
 itest/lnd-itest

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,47 @@
       "internalConsoleOptions": "neverOpen",
       "env": { "CI": "true" },
       "disableOptimisticBPs": true
-    }
+    },
+
+
+    {
+      "name": "test_custom_channels",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${workspaceFolder}/itest",
+      "args": [
+              "-test.v",
+              "-test.run=TestLightningTerminal/test_custom_channels",
+              "-loglevel=trace",
+              "-btcdexec=./btcd-itest",
+              "-litdexec=./litd-itest",
+              "-logdir=regtest",
+      ],
+      "env": {
+              "GOEXPERIMENT": "loopvar",
+              "GO111MODULE": "on"
+      },
+      "buildFlags": [
+              "-tags=dev monitoring autopilotrpc chainrpc invoicesrpc peersrpc routerrpc signrpc verrpc walletrpc watchtowerrpc wtclientrpc integration itest btcd",
+      ],
+      "hideSystemGoroutines": true,
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,58 +5,48 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug Tests",
-      "type": "node",
-      "request": "launch",
-      "runtimeExecutable": "${workspaceRoot}/app/node_modules/.bin/react-scripts",
-      "args": ["test", "--runInBand", "--no-cache", "--watchAll=false"],
-      "cwd": "${workspaceRoot}/app/",
-      "protocol": "inspector",
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
-      "env": { "CI": "true" },
-      "disableOptimisticBPs": true
-    },
-
-
-    {
-      "name": "test_custom_channels",
+      "name": "Debug itest",
       "type": "go",
       "request": "launch",
       "mode": "test",
+      "preLaunchTask": "reset before itest",
       "program": "${workspaceFolder}/itest",
-      "args": [
-              "-test.v",
-              "-test.run=TestLightningTerminal/test_custom_channels",
-              "-loglevel=trace",
-              "-btcdexec=./btcd-itest",
-              "-litdexec=./litd-itest",
-              "-logdir=regtest",
-      ],
       "env": {
               "GOEXPERIMENT": "loopvar",
               "GO111MODULE": "on"
       },
+      "args": [
+        "-test.v",
+        "-test.run=TestLightningTerminal/test_custom_channels",
+        "-loglevel=trace",
+        "-btcdexec=./btcd-itest",
+        "-logdir=${workspaceFolder}/itest/.logs",
+        "-litdexec=${workspaceFolder}/itest/litd-itest",
+      ],
       "buildFlags": [
-              "-tags=dev monitoring autopilotrpc chainrpc invoicesrpc peersrpc routerrpc signrpc verrpc walletrpc watchtowerrpc wtclientrpc integration itest btcd",
+              "-tags=dev integration itest autopilotrpc routerrpc signrpc verrpc walletrpc chainrpc invoicesrpc watchtowerrpc wtclientrpc peersrpc btcd monitoring",
       ],
       "hideSystemGoroutines": true,
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+    },
+    {
+      "name": "Debug Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "${workspaceRoot}/app/node_modules/.bin/react-scripts",
+      "args": [
+        "test",
+        "--runInBand",
+        "--no-cache",
+        "--watchAll=false"
+      ],
+      "cwd": "${workspaceRoot}/app/",
+      "protocol": "inspector",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "env": {
+        "CI": "true"
+      },
+      "disableOptimisticBPs": true
+    }
   ]
 }


### PR DESCRIPTION
Trying to find the best combination of options vs https://github.com/lightninglabs/lightning-terminal/pull/990. Would like some review on this, but github is not showing the diff properly. Here is the correct diff of the file of interest:


```
$ git diff general_itest_improvements alt_itest_improvements .vscode/launch.json
diff --git a/.vscode/launch.json b/.vscode/launch.json
index 3975819..a03f65e 100644
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,19 +12,21 @@
       "preLaunchTask": "reset before itest",
       "program": "${workspaceFolder}/itest",
       "env": {
-        "CGO_ENABLED": "0",
+              "GOEXPERIMENT": "loopvar",
+              "GO111MODULE": "on"
       },
       "args": [
         "-test.v",
         "-test.run=TestLightningTerminal/test_custom_channels",
-        "-logoutput",
+        "-loglevel=trace",
+        "-btcdexec=./btcd-itest",
         "-logdir=${workspaceFolder}/itest/.logs",
         "-litdexec=${workspaceFolder}/itest/litd-itest",
       ],
       "buildFlags": [
-        "-ldflags=-X github.com/lightningnetwork/lnd/build.RawTags=chainrpc,walletrpc,signrpc,invoicesrpc,autopilotrpc,watchtowerrpc,twclientrpc -X github.com/lightningnetwork/lnd/build.Commit=lightning-terminal-v0.4.0-alpha -X github.com/lightninglabs/loop.Commit=localbuild -X github.com/lightninglabs/pool.Commit=localbuild -X github.com/lightninglabs/lightning-terminal.Commit=localbuild",
-        "-tags=dev integration itest lowscrypt litd autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc neutrinorpc peersrpc",
+              "-tags=dev integration itest autopilotrpc routerrpc signrpc verrpc walletrpc chainrpc invoicesrpc watchtowerrpc wtclientrpc peersrpc btcd monitoring",
       ],
+      "hideSystemGoroutines": true,
     },
     {
       "name": "Debug Tests",
@@ -47,4 +49,4 @@
       "disableOptimisticBPs": true
     }
   ]
-}
\ No newline at end of file
+}
```




